### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/azure.yaml
+++ b/.github/workflows/azure.yaml
@@ -10,12 +10,12 @@ jobs:
         runs-on: ubuntu-latest
         steps: 
             - name: Check out the repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
             - name: Install Dependencies
               run: | 
                 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
             - name: Download Artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
               with:
                 name: daemonset
                 path: defender

--- a/.github/workflows/defender.yaml
+++ b/.github/workflows/defender.yaml
@@ -10,14 +10,14 @@ jobs:
         runs-on: ubuntu-latest
         steps: 
             - name: Check out the repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
             - name: Download the DaemonSet defender from PrismaCloud Compute Console
               run: |
                 CONSOLE_TOKEN=$(curl -s -k ${{ secrets.COMPUTE_API_ENDPOINT }}/api/v1/authenticate -X POST -H "Content-Type: application/json" -d '{"username":"${{ secrets.PRISMA_USERNAME }}", "password":"${{ secrets.PRISMA_PASSWORD }}"}' | grep -Po '"'"token"'"\s*:\s*"\K([^"]*)')
                 curl -s -k -O ${{ secrets.COMPUTE_API_ENDPOINT }}/api/v1/defenders/daemonset.yaml -H 'Content-Type: application/json' -H "Authorization: Bearer $CONSOLE_TOKEN" -d @defenderConfig.json
         
             - name: Upload Defender Manifest
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                 name: daemonset
                 path: daemonset.yaml


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions